### PR TITLE
Fix the race condition on close

### DIFF
--- a/gltest/app.d
+++ b/gltest/app.d
@@ -126,7 +126,6 @@ int main(string[] args) {
 				//glOutput.gl_makeCurrent();
 				glViewport(0, 0, event.window.width, event.window.height);
 			} else if (event.type == InputEventType.Keyboard && event.button.dir == 1) {
-				
 				switch (event.button.id) {
 				case ScanCode.F11:
 					int result;
@@ -135,6 +134,9 @@ int main(string[] args) {
 					isFullscreen = !isFullscreen;
 					writeln(result);
 					break;
+				case ScanCode.ESCAPE:
+				    isRunning = false;
+                    break;
 				default:
 					break;
 				}
@@ -143,6 +145,7 @@ int main(string[] args) {
 			Thread.sleep(dur!"msecs"(10));
 			//Input event polling part end
 		}
+		destroy(glOutput);
 		return 0;
 	} catch (Throwable t) {
 		writeln(t);

--- a/source/iota/controls/polling.d
+++ b/source/iota/controls/polling.d
@@ -652,6 +652,13 @@ version (Windows) {
 				output.type = InputEventType.init;
 				output.source = null;
 				return 0;
+			case ClientMessage:
+			    if (xe.xclient.data.l[0] == OSWindow.WM_DELETE_WINDOW) {
+					output.type = InputEventType.WindowClose;
+					output.handle = xe.xclient.window;
+					return 1;
+				}
+				goto default;
 			default:
 				return 0;
 		}

--- a/source/iota/window/fbdev.d
+++ b/source/iota/window/fbdev.d
@@ -70,7 +70,7 @@ public class OpenGLRenderer : FrameBufferRenderer {
 	protected GLenum		scaleQ;
 	protected bool			vSync;
 	protected int[2]		prevSizes;
-	protected GLfloat[] verticles = [
+	protected const GLfloat[] verticles = [
 	//	Position	TexCoords
 		-1.0, -1.0, 0.0, 0.0,	//Top-left
 		1.0, -1.0,  1.0, 0.0,	//Top-right


### PR DESCRIPTION
Just sending a quick fix for the race condition you mention in the README. 

I changed the gltest slightly to test with the ESCAPE key and things exited fine. After this test I could narrow things down and add the code for the X11 event handling. Seems to work now.

Also, the change to fbdev.d was made because I am compiling with OpenD and it is more strict about certain things, including the 'constness' of the verticles array. This change for OpenD still compiles with regular dmd, so I left it in here. 

You may ignore the fbdev.d change and the gltest change, of course...I just wanted to put them in here in case you or others were interested in these changes ;) 